### PR TITLE
Reverts AlignAndCallR2 to use the original MongoCallMtAndShifted. Als…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/settings.json

--- a/WDL/v2.6_MongoSwirl_Multi/AlignAndCallR2_v2_6_Multi.wdl
+++ b/WDL/v2.6_MongoSwirl_Multi/AlignAndCallR2_v2_6_Multi.wdl
@@ -111,7 +111,7 @@ workflow ParallelAlignAndCallR2 {
 
   Int M2_mem = if AlignToMtRegShiftedAndMetrics.max_mean_coverage > 25000 then 14 else 7
 
-  call ParallelMongoTasks_Multi.ParallelMongoCallMtAndShifted as CallMtAndShifted {
+  call MongoTasks_Multi.MongoCallMtAndShifted as CallMtAndShifted {
     input:
       sample_base_name = AlignToMtRegShiftedAndMetrics.samples,
       suffix = suffix,
@@ -143,9 +143,10 @@ workflow ParallelAlignAndCallR2 {
       gatk_override = gatk_override,
       gatk_docker_override = gatk_docker_override,
       gatk_version = gatk_version,
+      mem = M2_mem,
       preemptible_tries = preemptible_tries,
       JsonTools = JsonTools,
-      batch_size = batch_size,
+      #batch_size = batch_size,
       n_cpu = n_cpu
   }
 

--- a/WDL/v2.6_MongoSwirl_Multi/parallel_fullMitoPipeline_v2_6_Multi.wdl
+++ b/WDL/v2.6_MongoSwirl_Multi/parallel_fullMitoPipeline_v2_6_Multi.wdl
@@ -259,7 +259,7 @@ workflow MitochondriaPipeline {
       preemptible_tries = preemptible_tries,
       n_cpu_bwa = n_cpu_bwa,
       batch_size = batch_size,
-      n_cpu = n_cpu_m2_hc_lift
+      n_cpu = 8
   }
 
   call MongoTasks_Multi.MongoLiftoverVCFAndGetCoverage as LiftOverAfterSelf {


### PR DESCRIPTION
…o reduces CPU allocation to this function back down to 8 as it was for the 2022 (non-parallelized) run.